### PR TITLE
Handle null in reduce_numeric

### DIFF
--- a/jsonknife.c
+++ b/jsonknife.c
@@ -529,7 +529,7 @@ void reduce_numeric(void *acc, JsonbValue *val){
 
 	/* elog(INFO, "extract as number [%s] %s", nacc->element_type, jsonbv_to_string(NULL, val)); */
 
-	if( val == NULL ) {return;}
+	if( val == NULL || val->type == jbvNull) {return;}
 
 	if( val->type == jbvNumeric){
 


### PR DESCRIPTION
`SELECT knife_extract_max_numeric('{"a": null, "b": 2, "c": {"d": 5}}',
'[["a"],["b"],["c", "d"]]');` returns 5 instead of `ERROR:  Could not
extract as number`